### PR TITLE
implement multiplicative form for lgt and dlt

### DIFF
--- a/orbit/estimator.py
+++ b/orbit/estimator.py
@@ -605,6 +605,8 @@ class Estimator(object):
 
     def _convert_to_stan_inputs(self):
         """Collects stan attributes into a dict for `StanModel.sampling`"""
+        # todo: this should probably not be in the base class
+        #   and constants StanInputMapper should be model specific
         stan_input_set = set([each.name for each in StanInputMapper])
         stan_inputs = {}
         for key, value in self.__dict__.items():


### PR DESCRIPTION
Resolves #26 

Default behavior changed so that `is_mulltiplicative=True`.

This applies log transforms to all response and regressor cols, and exponentiates for predictions.

For prediction components, we compute by taking exp(log(prediction)) * log(component) for each component