### PR TITLE
mcmc samples reshape for 3 or even higher dimensional params

### DIFF
--- a/orbit/estimator.py
+++ b/orbit/estimator.py
@@ -408,7 +408,7 @@ class Estimator(object):
                         # here `order` is important to make samples flattened by chain
                         stan_extract[key] = val.flatten(order='F')
                     else:
-                        stan_extract[key] = val.reshape(-1, val.shape[-1], order='F')
+                        stan_extract[key] = val.reshape((-1, *val.shape[2:]), order='F')
 
                 # set posterior samples instance var
                 self._set_aggregate_posteriors(extract=stan_extract)


### PR DESCRIPTION
previous code doesn't work along with 3-d params (which are not used in LGT/DLT though)