### PR TITLE
fix non-seasonal pyro bug

### DIFF
--- a/orbit/pyro/lgt.py
+++ b/orbit/pyro/lgt.py
@@ -123,7 +123,7 @@ class Model:
                 s[t] = init_sea[..., t]
             s[self.seasonality] = init_sea[..., 0]
         else:
-            s = torch.zeros(num_of_obs)
+            s = [torch.tensor(0.)] * num_of_obs
 
         # states initial condition
         b[0] = torch.zeros_like(slp_sm)

--- a/tests/orbit/models/test_lgt.py
+++ b/tests/orbit/models/test_lgt.py
@@ -167,26 +167,26 @@ def test_lgt_non_seasonal_fit(synthetic_data, estimator_type):
     assert len(lgt._posterior_samples) == expected_num_parameters
 
 
-# def test_lgt_non_seasonal_fit_pyro(synthetic_data):
-#     train_df, test_df, coef = synthetic_data
-#
-#     lgt = LGTFull(
-#         response_col='response',
-#         date_col='week',
-#         estimator_type=PyroEstimatorVI,
-#         seasonality=1
-#     )
-#
-#     lgt.fit(train_df)
-#     predict_df = lgt.predict(test_df)
-#
-#     expected_columns = ['week', 'prediction']
-#     expected_shape = (51, len(expected_columns))
-#     expected_num_parameters = 10  # no `lp__` in pyro
-#
-#     assert predict_df.shape == expected_shape
-#     assert predict_df.columns.tolist() == expected_columns
-#     assert len(lgt._posterior_samples) == expected_num_parameters
+def test_lgt_non_seasonal_fit_pyro(synthetic_data):
+    train_df, test_df, coef = synthetic_data
+
+    lgt = LGTFull(
+        response_col='response',
+        date_col='week',
+        estimator_type=PyroEstimatorVI,
+        num_steps=10
+    )
+
+    lgt.fit(train_df)
+    predict_df = lgt.predict(test_df)
+
+    expected_columns = ['week', 'prediction']
+    expected_shape = (51, len(expected_columns))
+    expected_num_parameters = 10  # no `lp__` in pyro
+
+    assert predict_df.shape == expected_shape
+    assert predict_df.columns.tolist() == expected_columns
+    assert len(lgt._posterior_samples) == expected_num_parameters
 
 
 @pytest.mark.parametrize("estimator_type", [StanEstimatorMCMC, StanEstimatorVI, PyroEstimatorVI])


### PR DESCRIPTION
The root cause was because seasonality initialization in Pyro was being initialized to two separate kinds of objects

Closes #195 