### PR TITLE
Backtest debug

### DIFF
--- a/examples/Backtest_Orbit_Model.ipynb
+++ b/examples/Backtest_Orbit_Model.ipynb
@@ -23,8 +23,23 @@
    "execution_count": 1,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-09-02T20:20:25.698524Z",
-     "start_time": "2020-09-02T20:20:23.894930Z"
+     "end_time": "2020-09-25T07:04:46.168378Z",
+     "start_time": "2020-09-25T07:04:46.165446Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "sys.path.append(\"../\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-09-25T07:04:48.983111Z",
+     "start_time": "2020-09-25T07:04:47.182002Z"
     }
    },
    "outputs": [],
@@ -37,7 +52,7 @@
     "\n",
     "from orbit.models.lgt import LGTMAP, LGTAggregated\n",
     "from orbit.models.dlt import DLTMAP\n",
-    "from orbit.diagnostics.backtest import BackTester, TimeSeriesSplitter\n"
+    "from orbit.diagnostics.backtest import BackTester, TimeSeriesSplitter"
    ]
   },
   {
@@ -49,11 +64,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-09-02T20:20:25.716181Z",
-     "start_time": "2020-09-02T20:20:25.700283Z"
+     "end_time": "2020-09-25T07:04:53.246207Z",
+     "start_time": "2020-09-25T07:04:53.226772Z"
     }
    },
    "outputs": [
@@ -146,7 +161,7 @@
        "4 2010-01-31  538617        1.086926       0.776993   1.072525"
       ]
      },
-     "execution_count": 2,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -155,6 +170,7 @@
     "data_path = '../examples/data/iclaims_example.csv'\n",
     "raw_data = pd.read_csv(data_path, parse_dates=['week'])\n",
     "data = raw_data.copy()\n",
+    "\n",
     "print(data.shape)\n",
     "data.head(5)"
    ]
@@ -168,11 +184,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-09-02T20:20:25.722558Z",
-     "start_time": "2020-09-02T20:20:25.718945Z"
+     "end_time": "2020-09-25T07:04:56.609796Z",
+     "start_time": "2020-09-25T07:04:56.606459Z"
     }
    },
    "outputs": [],
@@ -188,11 +204,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-09-02T20:20:25.730485Z",
-     "start_time": "2020-09-02T20:20:25.725208Z"
+     "end_time": "2020-09-25T07:04:58.060807Z",
+     "start_time": "2020-09-25T07:04:58.054094Z"
     }
    },
    "outputs": [],
@@ -217,11 +233,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-09-02T20:20:26.748809Z",
-     "start_time": "2020-09-02T20:20:25.732545Z"
+     "end_time": "2020-09-25T07:05:00.116126Z",
+     "start_time": "2020-09-25T07:04:59.710810Z"
     }
    },
    "outputs": [],
@@ -238,11 +254,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-09-02T20:20:26.760006Z",
-     "start_time": "2020-09-02T20:20:26.750454Z"
+     "end_time": "2020-09-25T07:05:03.842377Z",
+     "start_time": "2020-09-25T07:05:03.832376Z"
     }
    },
    "outputs": [
@@ -328,7 +344,7 @@
        "4 2010-01-31         0          True  538617  567627.397584"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -354,11 +370,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-09-02T20:20:26.788925Z",
-     "start_time": "2020-09-02T20:20:26.762077Z"
+     "end_time": "2020-09-25T07:05:15.838360Z",
+     "start_time": "2020-09-25T07:05:15.814475Z"
     }
    },
    "outputs": [
@@ -574,7 +590,7 @@
        "[1080 rows x 10 columns]"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -589,16 +605,18 @@
    "source": [
     "## Backtest Scoring\n",
     "\n",
-    "The main purpose of `BackTester` are the evaluation metrics. Some of the most widely used metrics are implemented and built into the `BackTester` API"
+    "The main purpose of `BackTester` are the evaluation metrics. Some of the most widely used metrics are implemented and built into the `BackTester` API.\n",
+    "\n",
+    "The default metric list is **smape, wmape, mape, mse, mae, rmsse**."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-09-02T20:20:26.809122Z",
-     "start_time": "2020-09-02T20:20:26.792586Z"
+     "end_time": "2020-09-25T07:05:17.976004Z",
+     "start_time": "2020-09-25T07:05:17.965463Z"
     }
    },
    "outputs": [
@@ -632,37 +650,37 @@
        "    <tr>\n",
        "      <th>0</th>\n",
        "      <td>smape</td>\n",
-       "      <td>1.444929e-01</td>\n",
+       "      <td>1.923422e-01</td>\n",
        "      <td>False</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
        "      <td>wmape</td>\n",
-       "      <td>1.468023e-01</td>\n",
+       "      <td>1.743067e-01</td>\n",
        "      <td>False</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
        "      <td>mape</td>\n",
-       "      <td>1.511077e-01</td>\n",
+       "      <td>1.764645e-01</td>\n",
        "      <td>False</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
        "      <td>mse</td>\n",
-       "      <td>1.756961e+09</td>\n",
+       "      <td>5.365229e+09</td>\n",
        "      <td>False</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
        "      <td>mae</td>\n",
-       "      <td>3.865916e+04</td>\n",
+       "      <td>5.937043e+04</td>\n",
        "      <td>False</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>5</th>\n",
        "      <td>rmsse</td>\n",
-       "      <td>1.110708e+00</td>\n",
+       "      <td>1.405354e+00</td>\n",
        "      <td>False</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
@@ -671,15 +689,15 @@
       ],
       "text/plain": [
        "  metric_name  metric_values  is_training_metric\n",
-       "0       smape   1.444929e-01               False\n",
-       "1       wmape   1.468023e-01               False\n",
-       "2        mape   1.511077e-01               False\n",
-       "3         mse   1.756961e+09               False\n",
-       "4         mae   3.865916e+04               False\n",
-       "5       rmsse   1.110708e+00               False"
+       "0       smape   1.923422e-01               False\n",
+       "1       wmape   1.743067e-01               False\n",
+       "2        mape   1.764645e-01               False\n",
+       "3         mse   5.365229e+09               False\n",
+       "4         mae   5.937043e+04               False\n",
+       "5       rmsse   1.405354e+00               False"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -699,11 +717,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-09-02T20:20:26.816552Z",
-     "start_time": "2020-09-02T20:20:26.812212Z"
+     "end_time": "2020-09-25T07:06:10.438271Z",
+     "start_time": "2020-09-25T07:06:10.434289Z"
     },
     "code_folding": []
    },
@@ -721,11 +739,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-09-02T20:22:17.745817Z",
-     "start_time": "2020-09-02T20:22:17.736481Z"
+     "end_time": "2020-09-25T07:06:12.789013Z",
+     "start_time": "2020-09-25T07:06:12.779587Z"
     }
    },
    "outputs": [
@@ -759,13 +777,13 @@
        "    <tr>\n",
        "      <th>0</th>\n",
        "      <td>mse_naive</td>\n",
-       "      <td>1.424172e+09</td>\n",
+       "      <td>2.716543e+09</td>\n",
        "      <td>False</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
        "      <td>naive_error</td>\n",
-       "      <td>7.601139e+04</td>\n",
+       "      <td>8.061138e+04</td>\n",
        "      <td>False</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
@@ -774,11 +792,11 @@
       ],
       "text/plain": [
        "   metric_name  metric_values  is_training_metric\n",
-       "0    mse_naive   1.424172e+09               False\n",
-       "1  naive_error   7.601139e+04               False"
+       "0    mse_naive   2.716543e+09               False\n",
+       "1  naive_error   8.061138e+04               False"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -803,11 +821,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-09-02T20:20:26.845121Z",
-     "start_time": "2020-09-02T20:20:26.830101Z"
+     "end_time": "2020-09-25T07:06:16.019083Z",
+     "start_time": "2020-09-25T07:06:16.006133Z"
     }
    },
    "outputs": [
@@ -841,67 +859,67 @@
        "    <tr>\n",
        "      <th>0</th>\n",
        "      <td>smape</td>\n",
-       "      <td>1.444929e-01</td>\n",
+       "      <td>1.923422e-01</td>\n",
        "      <td>False</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
        "      <td>wmape</td>\n",
-       "      <td>1.468023e-01</td>\n",
+       "      <td>1.743067e-01</td>\n",
        "      <td>False</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
        "      <td>mape</td>\n",
-       "      <td>1.511077e-01</td>\n",
+       "      <td>1.764645e-01</td>\n",
        "      <td>False</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
        "      <td>mse</td>\n",
-       "      <td>1.756961e+09</td>\n",
+       "      <td>5.365229e+09</td>\n",
        "      <td>False</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
        "      <td>mae</td>\n",
-       "      <td>3.865916e+04</td>\n",
+       "      <td>5.937043e+04</td>\n",
        "      <td>False</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>5</th>\n",
        "      <td>rmsse</td>\n",
-       "      <td>1.110708e+00</td>\n",
+       "      <td>1.405354e+00</td>\n",
        "      <td>False</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>6</th>\n",
        "      <td>smape</td>\n",
-       "      <td>6.814792e-02</td>\n",
+       "      <td>6.769391e-02</td>\n",
        "      <td>True</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>7</th>\n",
        "      <td>wmape</td>\n",
-       "      <td>7.140660e-02</td>\n",
+       "      <td>7.139050e-02</td>\n",
        "      <td>True</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>8</th>\n",
        "      <td>mape</td>\n",
-       "      <td>6.839204e-02</td>\n",
+       "      <td>6.796322e-02</td>\n",
        "      <td>True</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>9</th>\n",
        "      <td>mse</td>\n",
-       "      <td>1.345638e+09</td>\n",
+       "      <td>1.577825e+09</td>\n",
        "      <td>True</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>10</th>\n",
        "      <td>mae</td>\n",
-       "      <td>2.409472e+04</td>\n",
+       "      <td>2.613738e+04</td>\n",
        "      <td>True</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
@@ -910,20 +928,20 @@
       ],
       "text/plain": [
        "   metric_name  metric_values  is_training_metric\n",
-       "0        smape   1.444929e-01               False\n",
-       "1        wmape   1.468023e-01               False\n",
-       "2         mape   1.511077e-01               False\n",
-       "3          mse   1.756961e+09               False\n",
-       "4          mae   3.865916e+04               False\n",
-       "5        rmsse   1.110708e+00               False\n",
-       "6        smape   6.814792e-02                True\n",
-       "7        wmape   7.140660e-02                True\n",
-       "8         mape   6.839204e-02                True\n",
-       "9          mse   1.345638e+09                True\n",
-       "10         mae   2.409472e+04                True"
+       "0        smape   1.923422e-01               False\n",
+       "1        wmape   1.743067e-01               False\n",
+       "2         mape   1.764645e-01               False\n",
+       "3          mse   5.365229e+09               False\n",
+       "4          mae   5.937043e+04               False\n",
+       "5        rmsse   1.405354e+00               False\n",
+       "6        smape   6.769391e-02                True\n",
+       "7        wmape   7.139050e-02                True\n",
+       "8         mape   6.796322e-02                True\n",
+       "9          mse   1.577825e+09                True\n",
+       "10         mae   2.613738e+04                True"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -943,11 +961,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-09-02T20:20:26.849930Z",
-     "start_time": "2020-09-02T20:20:26.847046Z"
+     "end_time": "2020-09-25T07:06:25.876529Z",
+     "start_time": "2020-09-25T07:06:25.873870Z"
     }
    },
    "outputs": [],
@@ -957,11 +975,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-09-02T20:20:26.862579Z",
-     "start_time": "2020-09-02T20:20:26.852138Z"
+     "end_time": "2020-09-25T07:06:26.423186Z",
+     "start_time": "2020-09-25T07:06:26.413248Z"
     }
    },
    "outputs": [
@@ -1021,7 +1039,7 @@
        "2       trend.job        Regular     0.000226"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1044,21 +1062,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-09-02T20:20:27.074110Z",
-     "start_time": "2020-09-02T20:20:26.864633Z"
+     "end_time": "2020-09-25T07:06:28.290930Z",
+     "start_time": "2020-09-25T07:06:28.117373Z"
     }
    },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<matplotlib.axes._subplots.AxesSubplot at 0x7faa210ea4a8>"
+       "<matplotlib.axes._subplots.AxesSubplot at 0x13b1e7110>"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -1101,11 +1119,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-09-02T20:20:27.079189Z",
-     "start_time": "2020-09-02T20:20:27.076414Z"
+     "end_time": "2020-09-25T07:06:30.022304Z",
+     "start_time": "2020-09-25T07:06:30.019240Z"
     }
    },
    "outputs": [],
@@ -1117,11 +1135,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 17,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-09-02T20:20:27.084017Z",
-     "start_time": "2020-09-02T20:20:27.081243Z"
+     "end_time": "2020-09-25T07:06:30.414482Z",
+     "start_time": "2020-09-25T07:06:30.411509Z"
     }
    },
    "outputs": [],
@@ -1132,11 +1150,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 18,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-09-02T20:20:27.090509Z",
-     "start_time": "2020-09-02T20:20:27.086409Z"
+     "end_time": "2020-09-25T07:06:30.734973Z",
+     "start_time": "2020-09-25T07:06:30.731160Z"
     }
    },
    "outputs": [
@@ -1172,21 +1190,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 19,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-09-02T20:20:27.280575Z",
-     "start_time": "2020-09-02T20:20:27.092894Z"
+     "end_time": "2020-09-25T07:06:31.420820Z",
+     "start_time": "2020-09-25T07:06:31.274662Z"
     }
    },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<matplotlib.axes._subplots.AxesSubplot at 0x7faa1b7babe0>"
+       "<matplotlib.axes._subplots.AxesSubplot at 0x13b5fc490>"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -1214,11 +1232,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 20,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-09-02T20:20:27.286481Z",
-     "start_time": "2020-09-02T20:20:27.283168Z"
+     "end_time": "2020-09-25T07:06:32.242115Z",
+     "start_time": "2020-09-25T07:06:32.238788Z"
     }
    },
    "outputs": [],
@@ -1229,21 +1247,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 21,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-09-02T20:20:27.474580Z",
-     "start_time": "2020-09-02T20:20:27.288981Z"
+     "end_time": "2020-09-25T07:06:32.732968Z",
+     "start_time": "2020-09-25T07:06:32.585323Z"
     }
    },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<matplotlib.axes._subplots.AxesSubplot at 0x7faa210ea0b8>"
+       "<matplotlib.axes._subplots.AxesSubplot at 0x13b6608d0>"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -1278,11 +1296,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 22,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-09-02T20:20:27.479383Z",
-     "start_time": "2020-09-02T20:20:27.476508Z"
+     "end_time": "2020-09-25T07:06:34.398328Z",
+     "start_time": "2020-09-25T07:06:34.395028Z"
     }
    },
    "outputs": [],
@@ -1293,21 +1311,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 23,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-09-02T20:20:27.670402Z",
-     "start_time": "2020-09-02T20:20:27.481427Z"
+     "end_time": "2020-09-25T07:06:35.161911Z",
+     "start_time": "2020-09-25T07:06:34.966664Z"
     }
    },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<matplotlib.axes._subplots.AxesSubplot at 0x7faa21c056d8>"
+       "<matplotlib.axes._subplots.AxesSubplot at 0x13b6ce850>"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -1325,13 +1343,20 @@
    "source": [
     "ex_splitter2.plot()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "orbit",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "orbit"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1343,7 +1368,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.7.7"
   },
   "toc": {
    "base_numbering": 1,

--- a/examples/Backtest_Orbit_Model.ipynb
+++ b/examples/Backtest_Orbit_Model.ipynb
@@ -20,21 +20,6 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2020-09-25T07:04:46.168378Z",
-     "start_time": "2020-09-25T07:04:46.165446Z"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "import sys\n",
-    "sys.path.append(\"../\")"
-   ]
-  },
-  {
-   "cell_type": "code",
    "execution_count": 2,
    "metadata": {
     "ExecuteTime": {

--- a/orbit/__init__.py
+++ b/orbit/__init__.py
@@ -1,2 +1,2 @@
 name = 'orbit'
-__version__ = '1.0.0'
+__version__ = '1.0.2'

--- a/orbit/diagnostics/backtest.py
+++ b/orbit/diagnostics/backtest.py
@@ -213,10 +213,10 @@ class BackTester(object):
         # init private vars
         self._n_splits = 0
         self._set_n_splits()
-        self._test_actual = None
-        self._test_predicted = None
-        self._train_actual = None
-        self._train_predicted = None
+        self._test_actual = []
+        self._test_predicted = []
+        self._train_actual = []
+        self._train_predicted = []
 
         # init df for actuals and predictions
         self._predicted_df = pd.DataFrame(
@@ -271,10 +271,10 @@ class BackTester(object):
             # set attributes
             self._fitted_models.append(model_copy)
             self._splitter_scheme.append(scheme)
-            self._test_actual = test_df[response_col].to_numpy()
-            self._test_predicted = test_predictions['prediction'].to_numpy()
-            self._train_actual = train_df[response_col].to_numpy()
-            self._train_predicted = train_predictions['prediction'].to_numpy()
+            self._test_actual = np.concatenate((self._test_actual, test_df[response_col].to_numpy()))
+            self._test_predicted = np.concatenate((self._test_predicted, test_predictions['prediction'].to_numpy()))
+            self._train_actual = np.concatenate((self._train_actual, train_df[response_col].to_numpy()))
+            self._train_predicted = np.concatenate((self._train_predicted, train_predictions['prediction'].to_numpy()))
 
             # set df attribute
             # join train

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ from setuptools.command.test import test as test_command
 # #   https://bugs.python.org/issue23102
 # dist.Distribution().fetch_build_eggs(['cython'])
 
-VERSION = '1.0.1'
+VERSION = '1.0.2'
 DESCRIPTION = "Orbit is a package for bayesian time series modeling and inference."
 AUTHOR = '''Edwin Ng <edwinng@uber.com>, Steve Yang <steve.yang@uber.com>,
             Huigang Chen <huigang@uber.com>, Zhishi Wang <zhishiw@uber.com>'''


### PR DESCRIPTION
fix #220 
there is a bug in current backtest code, where only actuals and predictions in the last split are used to calculate the metrics.