### PR TITLE
Change percentiles default

### DIFF
--- a/orbit/diagnostics/plot.py
+++ b/orbit/diagnostics/plot.py
@@ -19,7 +19,7 @@ if os.environ.get('DISPLAY', '') == '':
     matplotlib.use('Agg')
 
 
-def plot_predicted_data(training_actual_df, predicted_df, date_col, actual_col, pred_col,
+def plot_predicted_data(training_actual_df, predicted_df, date_col, actual_col, pred_col='prediction',
                         title="", test_actual_df=None,
                         is_visible=True, figsize=None, path=None):
     """

--- a/orbit/models/lgt.py
+++ b/orbit/models/lgt.py
@@ -785,7 +785,8 @@ class LGTFull(BaseLGT):
         Number of bootstrap samples to draw from the initial MCMC or VI posterior samples.
         If None, use the original posterior draws.
     prediction_percentiles : list
-        List of integers of prediction percentiles that should be returned on prediction.
+        List of integers of prediction percentiles that should be returned on prediction. To avoid reporting any
+        confident intervals, pass an empty list
     kwargs
         Additional args to pass to parent classes.
 
@@ -807,8 +808,8 @@ class LGTFull(BaseLGT):
         self._validate_supported_estimator_type()
 
     def _set_default_args(self):
-        if not self.prediction_percentiles:
-            self._prediction_percentiles = list()
+        if self.prediction_percentiles is None:
+            self._prediction_percentiles = [5, 95]
         else:
             self._prediction_percentiles = copy(self.prediction_percentiles)
 

--- a/tests/orbit/models/test_dlt.py
+++ b/tests/orbit/models/test_dlt.py
@@ -106,7 +106,7 @@ def test_dlt_non_seasonal_fit(synthetic_data, estimator_type):
     dlt.fit(train_df)
     predict_df = dlt.predict(test_df)
 
-    expected_columns = ['week', 'prediction']
+    expected_columns = ['week', 'prediction_lower', 'prediction', 'prediction_upper']
     expected_shape = (51, len(expected_columns))
     expected_num_parameters = 11
 

--- a/tests/orbit/models/test_lgt.py
+++ b/tests/orbit/models/test_lgt.py
@@ -159,7 +159,7 @@ def test_lgt_non_seasonal_fit(synthetic_data, estimator_type):
     lgt.fit(train_df)
     predict_df = lgt.predict(test_df)
 
-    expected_columns = ['week', 'prediction']
+    expected_columns = ['week', 'prediction_lower', 'prediction', 'prediction_upper']
     expected_shape = (51, len(expected_columns))
     expected_num_parameters = 11
 
@@ -181,7 +181,7 @@ def test_lgt_non_seasonal_fit_pyro(synthetic_data):
     lgt.fit(train_df)
     predict_df = lgt.predict(test_df)
 
-    expected_columns = ['week', 'prediction']
+    expected_columns = ['week', 'prediction_lower', 'prediction', 'prediction_upper']
     expected_shape = (51, len(expected_columns))
     expected_num_parameters = 10  # no `lp__` in pyro
 


### PR DESCRIPTION
## Description

Changing default value of prediction percentile.  

Fixes # (issue)

Having a default percentiles make more sense as a Full Bayesian Estimator.  It also changes default plotting arg to reduce code in many demos.

- [ ] This change requires a documentation update

## How Has This Been Tested?

I don't think additional unit test needed unless we want to add basic test for plotting utils
