### PR TITLE
Add support for multiple prediction percentiles

### DIFF
--- a/orbit/diagnostics/plot.py
+++ b/orbit/diagnostics/plot.py
@@ -19,9 +19,9 @@ if os.environ.get('DISPLAY', '') == '':
     matplotlib.use('Agg')
 
 
-def plot_predicted_data(training_actual_df, predicted_df, date_col, actual_col, pred_col='prediction',
-                        title="", test_actual_df=None,
-                        is_visible=True, figsize=None, path=None):
+def plot_predicted_data(training_actual_df, predicted_df, date_col, actual_col,
+                        pred_col='prediction', prediction_percentiles=None,
+                        title="", test_actual_df=None, is_visible=True, figsize=None, path=None):
     """
     plot training actual response together with predicted data; if actual response of predicted
     data is there, plot it too.
@@ -31,7 +31,10 @@ def plot_predicted_data(training_actual_df, predicted_df, date_col, actual_col, 
         training actual response data frame. two columns required: actual_col and date_col
     predicted_df: pd.DataFrame
         predicted data response data frame. two columns required: actual_col and pred_col. If
-        user provide pred_percentiles_col, it needs to include them as well.
+        user provide prediction_percentiles, it needs to include them as well in such
+        `prediction_{x}` where x is the correspodent percentiles
+    prediction_percentiles: list
+        list of two elements indicates the lower and upper percentiles
     date_col: str
         the date column name
     actual_col: str
@@ -39,7 +42,7 @@ def plot_predicted_data(training_actual_df, predicted_df, date_col, actual_col, 
     title: str
         title of the plot
     test_actual_df: pd.DataFrame
-       test actual response dataframe. two columns required: actual_col and date_co
+       test actual response dataframe. two columns required: actual_col and date_col
     is_visible: boolean
         whether we want to show the plot. If called from unittest, is_visible might = False.
     figsize: tuple
@@ -55,18 +58,27 @@ def plot_predicted_data(training_actual_df, predicted_df, date_col, actual_col, 
         raise ValueError("No prediction data or training response to plot.")
 
     plot_confid = False
-    # labels for confidence intervals
-    confid_cols = [pred_col + "_lower", pred_col + "_upper"]
+    if prediction_percentiles is None:
+        _pred_percentiles = [5, 95]
+    else:
+        _pred_percentiles = prediction_percentiles
+
+    if len(_pred_percentiles) != 2:
+        raise ValueError("prediction_percentiles has to be None or a list with length=2.")
+
+    confid_cols = ['prediction_{}'.format(_pred_percentiles[0]),
+                   'prediction_{}'.format(_pred_percentiles[1])]
+
     if set(confid_cols).issubset(predicted_df.columns):
         plot_confid = True
 
-    _training_actual_df = training_actual_df.copy()
-    _predicted_df=predicted_df.copy()
-    _training_actual_df[date_col] = pd.to_datetime(_training_actual_df[date_col])
-    _predicted_df[date_col] = pd.to_datetime(_predicted_df[date_col])
-
     if not figsize:
         figsize=(16, 8)
+
+    _training_actual_df = training_actual_df.copy()
+    _predicted_df = predicted_df.copy()
+    _training_actual_df[date_col] = pd.to_datetime(_training_actual_df[date_col])
+    _predicted_df[date_col] = pd.to_datetime(_predicted_df[date_col])
 
     fig, ax = plt.subplots(facecolor='w', figsize=figsize)
 
@@ -79,7 +91,7 @@ def plot_predicted_data(training_actual_df, predicted_df, date_col, actual_col, 
             marker=None, color='#12939A', lw=2, label='prediction')
 
     if test_actual_df is not None:
-        test_actual_df=test_actual_df.copy()
+        test_actual_df = test_actual_df.copy()
         test_actual_df[date_col] = pd.to_datetime(test_actual_df[date_col])
         ax.scatter(test_actual_df[date_col].values,
                    test_actual_df[actual_col].values,
@@ -97,12 +109,12 @@ def plot_predicted_data(training_actual_df, predicted_df, date_col, actual_col, 
     ax.grid(True, which='major', c='gray', ls='-', lw=1, alpha=0.5)
     ax.legend()
     if path:
-        plt.savefig(path)
+        fig.savefig(path)
     if is_visible:
         plt.show()
 
 
-def plot_predicted_components(predicted_df, date_col, figsize=None, path=None):
+def plot_predicted_components(predicted_df, date_col, prediction_percentiles=None, figsize=None, path=None):
     """ Plot predicted componenets with the data frame of decomposed prediction where components
     has been pre-defined as `trend`, `seasonality` and `regression`.
     Parameters
@@ -112,6 +124,9 @@ def plot_predicted_components(predicted_df, date_col, figsize=None, path=None):
         user provide pred_percentiles_col, it needs to include them as well.
     date_col: str
         the date column name
+    prediction_percentiles: list
+        a list should consist exact two elements which will be used to plot as lower and upper bound of
+        confidence interval
     title: str
         title of the plot
     figsize: tuple
@@ -120,7 +135,7 @@ def plot_predicted_components(predicted_df, date_col, figsize=None, path=None):
         path to save the figure
    Returns
     -------
-        None.
+        None
     """
 
     _predicted_df=predicted_df.copy()
@@ -132,11 +147,19 @@ def plot_predicted_components(predicted_df, date_col, figsize=None, path=None):
     if not figsize:
         figsize=(16, 8)
 
+    if prediction_percentiles is None:
+        _pred_percentiles = [5, 95]
+    else:
+        _pred_percentiles = prediction_percentiles
+
+    if len(_pred_percentiles) != 2:
+        raise ValueError("prediction_percentiles has to be None or a list with length=2.")
+
     fig, axes = plt.subplots(n_panels, 1, facecolor='w', figsize=figsize)
     for ax, comp in zip(axes, plot_components):
         y = predicted_df[comp].values
         ax.plot(_predicted_df[date_col], y, marker=None, color='#12939A')
-        confid_cols = [comp + "_lower", comp + "_upper"]
+        confid_cols = ["{}_{}".format(comp, _pred_percentiles[0]), "{}_{}".format(comp, _pred_percentiles[1])]
         if set(confid_cols).issubset(predicted_df.columns):
             ax.fill_between(_predicted_df[date_col].values,
                             _predicted_df[confid_cols[0]],

--- a/orbit/models/lgt.py
+++ b/orbit/models/lgt.py
@@ -845,7 +845,6 @@ class LGTFull(BaseLGT):
 
     def _aggregate_full_predictions(self, array, label, percentiles):
         """Aggregates the mcmc prediction to a point estimate
-
         Args
         ----
         array: np.ndarray
@@ -862,13 +861,8 @@ class LGTFull(BaseLGT):
         """
 
         aggregated_array = np.percentile(array, percentiles, axis=0)
-        if len(percentiles) == 1:
-            aggregate_df = pd.DataFrame(aggregated_array.T, columns=[label])
-        elif len(percentiles) == 3:
-            aggregate_df = pd.DataFrame(aggregated_array.T, columns=[label + "_lower", label, label + "_upper"])
-        else:
-            raise PredictionException("Invalid input percentiles.")
-
+        columns = [label + "_" + str(p) if p != 50 else label for p in percentiles]
+        aggregate_df = pd.DataFrame(aggregated_array.T, columns=columns)
         return aggregate_df
 
     def predict(self, df, decompose=False):

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,4 @@ torch
 tqdm
 seaborn>=0.10.0
 pyro-ppl==1.4.0
-statsmodels==0.11.1
+statsmodels>=0.11.1

--- a/tests/orbit/models/test_dlt.py
+++ b/tests/orbit/models/test_dlt.py
@@ -36,7 +36,7 @@ def test_dlt_full_univariate(synthetic_data, estimator_type):
     dlt.fit(train_df)
     predict_df = dlt.predict(test_df)
 
-    expected_columns = ['week', 'prediction_lower', 'prediction', 'prediction_upper']
+    expected_columns = ['week', 'prediction_5', 'prediction', 'prediction_95']
     expected_shape = (51, len(expected_columns))
     expected_num_parameters = 13
 
@@ -106,7 +106,7 @@ def test_dlt_non_seasonal_fit(synthetic_data, estimator_type):
     dlt.fit(train_df)
     predict_df = dlt.predict(test_df)
 
-    expected_columns = ['week', 'prediction_lower', 'prediction', 'prediction_upper']
+    expected_columns = ['week', 'prediction_5', 'prediction', 'prediction_95']
     expected_shape = (51, len(expected_columns))
     expected_num_parameters = 11
 
@@ -146,7 +146,7 @@ def test_dlt_full_with_regression(synthetic_data, estimator_type, regressor_sign
     regression_out = dlt.get_regression_coefs()
     num_regressors = regression_out.shape[0]
 
-    expected_columns = ['week', 'prediction_lower', 'prediction', 'prediction_upper']
+    expected_columns = ['week', 'prediction_5', 'prediction', 'prediction_95']
     expected_shape = (51, len(expected_columns))
     expected_regression_shape = (6, 3)
 

--- a/tests/orbit/models/test_lgt.py
+++ b/tests/orbit/models/test_lgt.py
@@ -38,7 +38,7 @@ def test_lgt_full_univariate(synthetic_data, estimator_type):
     lgt.fit(train_df)
     predict_df = lgt.predict(test_df)
 
-    expected_columns = ['week', 'prediction_lower', 'prediction', 'prediction_upper']
+    expected_columns = ['week', 'prediction_5', 'prediction', 'prediction_95']
     expected_shape = (51, len(expected_columns))
     expected_num_parameters = 13
 
@@ -63,7 +63,7 @@ def test_lgt_full_univariate_pyro(synthetic_data):
     lgt.fit(train_df)
     predict_df = lgt.predict(test_df)
 
-    expected_columns = ['week', 'prediction_lower', 'prediction', 'prediction_upper']
+    expected_columns = ['week', 'prediction_5', 'prediction', 'prediction_95']
     expected_shape = (51, len(expected_columns))
     expected_num_parameters = 12  # no `lp__` in pyro
 
@@ -159,7 +159,7 @@ def test_lgt_non_seasonal_fit(synthetic_data, estimator_type):
     lgt.fit(train_df)
     predict_df = lgt.predict(test_df)
 
-    expected_columns = ['week', 'prediction_lower', 'prediction', 'prediction_upper']
+    expected_columns =    ['week', 'prediction_5', 'prediction', 'prediction_95']
     expected_shape = (51, len(expected_columns))
     expected_num_parameters = 11
 
@@ -181,7 +181,7 @@ def test_lgt_non_seasonal_fit_pyro(synthetic_data):
     lgt.fit(train_df)
     predict_df = lgt.predict(test_df)
 
-    expected_columns = ['week', 'prediction_lower', 'prediction', 'prediction_upper']
+    expected_columns = ['week', 'prediction_5', 'prediction', 'prediction_95']
     expected_shape = (51, len(expected_columns))
     expected_num_parameters = 10  # no `lp__` in pyro
 
@@ -234,7 +234,7 @@ def test_lgt_full_with_regression(synthetic_data, estimator_type, regressor_sign
     regression_out = lgt.get_regression_coefs()
     num_regressors = regression_out.shape[0]
 
-    expected_columns = ['week', 'prediction_lower', 'prediction', 'prediction_upper']
+    expected_columns = ['week', 'prediction_5', 'prediction', 'prediction_95']
     expected_shape = (51, len(expected_columns))
     expected_regression_shape = (6, 3)
 


### PR DESCRIPTION
## Description

Support multiple prediction percentiles. Fixes #261 should also close #250 

- [x] Unit test
- [x] New feature

tested cases when prediction_percentiles `= [5, 10, 95]` and `= None`