### PR TITLE
Plotting Refinement

### DIFF
--- a/docs/tutorials/decompose_prediction.ipynb
+++ b/docs/tutorials/decompose_prediction.ipynb
@@ -25,6 +25,7 @@
    },
    "outputs": [],
    "source": [
+    "%matplotlib inline\n",
     "import pandas as pd\n",
     "import numpy as np\n",
     "from orbit.models.dlt import DLTMAP, DLTFull\n",
@@ -197,7 +198,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.6.8"
   },
   "toc": {
    "base_numbering": 1,

--- a/docs/tutorials/dlt.ipynb
+++ b/docs/tutorials/dlt.ipynb
@@ -72,6 +72,7 @@
    },
    "outputs": [],
    "source": [
+    "%matplotlib inline\n",
     "import pandas as pd\n",
     "import numpy as np\n",
     "from orbit.models.dlt import DLTMAP, DLTFull, DLTAggregated\n",
@@ -625,7 +626,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.6.8"
   },
   "toc": {
    "base_numbering": 1,

--- a/docs/tutorials/lgt.ipynb
+++ b/docs/tutorials/lgt.ipynb
@@ -60,6 +60,7 @@
    },
    "outputs": [],
    "source": [
+    "%matplotlib inline\n",
     "import pandas as pd\n",
     "import numpy as np\n",
     "from orbit.models.lgt import LGTMAP, LGTAggregated, LGTFull\n",
@@ -162,8 +163,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 227 ms, sys: 14 ms, total: 241 ms\n",
-      "Wall time: 527 ms\n"
+      "CPU times: user 223 ms, sys: 9.22 ms, total: 232 ms\n",
+      "Wall time: 317 ms\n"
      ]
     }
    ],
@@ -265,8 +266,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 74.3 ms, sys: 64.2 ms, total: 138 ms\n",
-      "Wall time: 8.14 s\n"
+      "CPU times: user 70.2 ms, sys: 67 ms, total: 137 ms\n",
+      "Wall time: 8.44 s\n"
      ]
     }
    ],
@@ -320,7 +321,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.6.8"
   },
   "toc": {
    "base_numbering": 1,

--- a/docs/tutorials/pyro_basic.ipynb
+++ b/docs/tutorials/pyro_basic.ipynb
@@ -29,6 +29,7 @@
    },
    "outputs": [],
    "source": [
+    "%matplotlib inline\n",
     "import pandas as pd\n",
     "import numpy as np\n",
     "from orbit.models.lgt import LGTMAP, LGTAggregated, LGTFull\n",
@@ -303,7 +304,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.6.8"
   },
   "toc": {
    "base_numbering": 1,

--- a/docs/tutorials/quick_start.ipynb
+++ b/docs/tutorials/quick_start.ipynb
@@ -18,6 +18,7 @@
    },
    "outputs": [],
    "source": [
+    "%matplotlib inline\n",
     "import pandas as pd\n",
     "import numpy as np\n",
     "import warnings\n",
@@ -210,7 +211,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.6.8"
   },
   "toc": {
    "base_numbering": 1,

--- a/orbit/diagnostics/plot.py
+++ b/orbit/diagnostics/plot.py
@@ -114,8 +114,8 @@ def plot_predicted_data(training_actual_df, predicted_df, date_col, actual_col,
         plt.show()
 
 
-def plot_predicted_components(predicted_df, date_col, prediction_percentiles=None, title="", figsize=None, path=None,
-                             plot_components=None):
+def plot_predicted_components(predicted_df, date_col, prediction_percentiles=None, plot_components=None,
+                              title="", figsize=None, path=None):
     """ Plot predicted componenets with the data frame of decomposed prediction where components
     has been pre-defined as `trend`, `seasonality` and `regression`.
     Parameters
@@ -128,6 +128,9 @@ def plot_predicted_components(predicted_df, date_col, prediction_percentiles=Non
     prediction_percentiles: list
         a list should consist exact two elements which will be used to plot as lower and upper bound of
         confidence interval
+    plot_components: list
+        a list of strings to show the label of components to be plotted; by default, it uses values in
+        `orbit.constants.constants.PredictedComponents`.
     title: str
         title of the plot
     figsize: tuple
@@ -215,8 +218,8 @@ def metric_horizon_barplot(df, model_col='model', pred_horizon_col='pred_horizon
 
 
 def plot_posterior_params(mod, kind='density', n_bins=20, ci_level=.95,
-                         pair_type='scatter', figsize=None, path=None,
-                         incl_trend_params=False, incl_smooth_params=False):
+                          pair_type='scatter', figsize=None, path=None,
+                          incl_trend_params=False, incl_smooth_params=False):
     """ Data Viz for posterior samples
 
     Params
@@ -280,7 +283,7 @@ def plot_posterior_params(mod, kind='density', n_bins=20, ci_level=.95,
             mean = np.mean(samples)
             median = np.median(samples)
             cred_min, cred_max = np.percentile(samples, 100 * (1 - ci_level)/2), \
-                                    np.percentile(samples, 100 * (1 + ci_level)/2)
+                                 np.percentile(samples, 100 * (1 + ci_level)/2)
 
             sns.distplot(samples, bins=n_bins, kde_kws={'shade':True}, ax=axes[i], norm_hist=False)
             # sns.kdeplot(samples, shade=True, ax=axes[i])

--- a/orbit/diagnostics/plot.py
+++ b/orbit/diagnostics/plot.py
@@ -114,7 +114,8 @@ def plot_predicted_data(training_actual_df, predicted_df, date_col, actual_col,
         plt.show()
 
 
-def plot_predicted_components(predicted_df, date_col, prediction_percentiles=None, figsize=None, path=None):
+def plot_predicted_components(predicted_df, date_col, prediction_percentiles=None, title="", figsize=None, path=None,
+                             plot_components=None):
     """ Plot predicted componenets with the data frame of decomposed prediction where components
     has been pre-defined as `trend`, `seasonality` and `regression`.
     Parameters
@@ -140,9 +141,12 @@ def plot_predicted_components(predicted_df, date_col, prediction_percentiles=Non
 
     _predicted_df=predicted_df.copy()
     _predicted_df[date_col] = pd.to_datetime(_predicted_df[date_col])
-    plot_components = [PredictedComponents.TREND.value,
-                       PredictedComponents.SEASONALITY.value,
-                       PredictedComponents.REGRESSION.value]
+    if plot_components is None:
+        plot_components = [PredictedComponents.TREND.value,
+                           PredictedComponents.SEASONALITY.value,
+                           PredictedComponents.REGRESSION.value]
+
+    plot_components = [p for p in plot_components if p in _predicted_df.columns.tolist()]
     n_panels = len(plot_components)
     if not figsize:
         figsize=(16, 8)
@@ -167,6 +171,7 @@ def plot_predicted_components(predicted_df, date_col, prediction_percentiles=Non
                             facecolor='#42999E', alpha=0.5)
         ax.grid(True, which='major', c='gray', ls='-', lw=1, alpha=0.5)
         ax.set_title(comp, fontsize=16)
+    plt.suptitle(title, fontsize=16)
     fig.tight_layout()
 
     if path:


### PR DESCRIPTION
## Description

I increase flexibility of `plot_predicted_components` such that it doesn't necessary to plot all of these components: trend, seasonality and regression.  It also allows user to input customize tag of the components.  Since we have another issue asks about the tutorial plot #271 .  Let's use this PR to revisit the needs of change as well on the tutorial doc.

Fixes # (issue)

propose to fix #271 

Task:
- [x] plot components enhance
- [x] doc refresh

## How Has This Been Tested?
Make sure new tutorial render similar plot.