### PR TITLE
fix #299 - remove enum34 dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@ pystan==2.19.1.1
 matplotlib==3.2.1
 scipy>=1.4.1
 scikit-learn
-enum34==1.1.6
 torch
 tqdm
 seaborn>=0.10.0


### PR DESCRIPTION
## Description

- Remove `enum34` from `requirements.txt`

Fixes #299 

## Type of change

- Bug fix

## How Has This Been Tested?
I wasn't able to find contributing guidelines nor a dev guide, so I hope the following steps are correct.

```
virtualenv -p python37 venv
source venv/bin/activate
pip install --quiet -r requirements.txt 
pip install --quiet -r requirements-test.txt 
pytest
```

Output:
```
71 passed, 19 warnings
```