### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,8 +96,8 @@ plot_predicted_data(
 # Contributing
 
 We welcome community contributors to the project. Before you start, please read our 
-[code of conduct](https://github.com/uber/orbit/blob/master/CODE_OF_CONDUCT.md) and check out 
-[contributing guidelines](https://github.com/uber/orbit/blob/master/CONTRIBUTING.md) first.
+[code of conduct](CODE_OF_CONDUCT.md) and check out 
+[contributing guidelines](CONTRIBUTING.md) first.
 
 # References
 

--- a/README.md
+++ b/README.md
@@ -95,9 +95,9 @@ plot_predicted_data(
 
 # Contributing
 
-We welcome community contributors to the project. Before you start, please read our 
-[code of conduct](CODE_OF_CONDUCT.md) and check out 
-[contributing guidelines](CONTRIBUTING.md) first.
+We welcome community contributors to the project. Before you start, please read our
+[code of conduct](https://github.com/uber/orbit/blob/dev/CODE_OF_CONDUCT.md) and check out
+[contributing guidelines](https://github.com/uber/orbit/blob/dev/CONTRIBUTING.md) first.
 
 # References
 


### PR DESCRIPTION
relative paths for contribution docs

## Description

The links of code of conduct and contributing guidelines are in absolute path `https://github.com/uber/orbit/blob/master/` which does not contain the docs.

The links should be relative paths so that the links work in GitHub `README.md` homepage in every branch.
I replaced them with relative paths as described in [GitHub Docs About READMEs](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-readmes).

## Type of change

- [✅] Bug fix

## How Has This Been Tested?

Created a branch with the relative links and push it into GitHub. Went to the README.md homepage and click the links! For example, my branch for the pull request [pochoi-contr-links](https://github.com/pochoi/orbit/tree/pochoi-contr-links).
