### PR TITLE
Dev ktrx2 asym gavin

### DIFF
--- a/orbit/constants/ktrx.py
+++ b/orbit/constants/ktrx.py
@@ -40,6 +40,7 @@ class DataInputMapper(Enum):
     # --------------- mvn
     MVN = 'MVN'
     GEOMETRIC_WALK = 'GEOMETRIC_WALK'
+    KERNEL_ASYM = 'KERNEL_ASYM'
 
 
 class BaseSamplingParameters(Enum):

--- a/orbit/models/ktrx.py
+++ b/orbit/models/ktrx.py
@@ -103,6 +103,7 @@ class BaseKTRX(BaseTemplate):
                  flat_multiplier=False,
                  geometric_walk=True,
                  min_residuals_sd=0.5,
+                 kernel_asym=[1.0,1.0],
                  **kwargs):
         super().__init__(**kwargs)  # create estimator in base class
 
@@ -141,6 +142,8 @@ class BaseKTRX(BaseTemplate):
         self.flat_multiplier = flat_multiplier
         self.geometric_walk = geometric_walk
         self.min_residuals_sd = min_residuals_sd
+        # the kernel asymmetry 
+        self.kernel_asym = kernel_asym
 
         # set private var to arg value
         # if None set default in _set_default_args()
@@ -439,7 +442,7 @@ class BaseKTRX(BaseTemplate):
                 )
                 self._knots_idx_coef = list(self._knots_idx_coef.astype(np.int32))
 
-            kernel_coefficients = gauss_kernel(tp, self._knots_tp_coefficients, rho=self.rho_coefficients)
+            kernel_coefficients = gauss_kernel(tp, self._knots_tp_coefficients, rho=self.rho_coefficients, norm = self.kernel_asym)
 
             self._num_knots_coefficients = len(self._knots_tp_coefficients)
             self._kernel_coefficients = kernel_coefficients
@@ -847,7 +850,7 @@ class BaseKTRX(BaseTemplate):
             new_tp = np.arange(start + 1, start + output_len + 1) / self.num_of_observations
 
             if coefficient_method == 'smooth':
-                kernel_coefficients = gauss_kernel(new_tp, self._knots_tp_coefficients, rho=self.rho_coefficients)
+                kernel_coefficients = gauss_kernel(new_tp, self._knots_tp_coefficients, rho=self.rho_coefficients, norm = self.kernel_asym)
                 # kernel_coefficients = parabolic_kernel(new_tp, self._knots_tp_coefficients)
                 coef_knots = model.get(constants.RegressionSamplingParameters.COEFFICIENTS_KNOT.value)
                 regressor_betas = np.matmul(coef_knots, kernel_coefficients.transpose((1, 0)))

--- a/orbit/utils/kernels.py
+++ b/orbit/utils/kernels.py
@@ -9,7 +9,7 @@ def reduce_by_max(x, n=2):
 
 # Gaussian-Kernel
 # https://en.wikipedia.org/wiki/Kernel_smoother
-def gauss_kernel(x, x_i, rho=1.0, alpha=1.0, n_reduce=-1, point_to_flatten=1):
+def gauss_kernel_old(x, x_i, rho=1.0, alpha=1.0, n_reduce=-1, point_to_flatten=1):
     """
     Parameters
     ----------
@@ -127,6 +127,69 @@ def parabolic_kernel(x, x_i):
         k[np_idx, M - 1] = 1
 
     # TODO: it is probably not needed
+    k = k / np.sum(k, axis=1, keepdims=True)
+
+    return k
+
+
+def is_neg(x):
+    out = np.divide(x-np.absolute(x),-2*np.absolute(x),out=np.zeros_like(x), where=np.absolute(x)!=0.0 )
+    out = np.absolute(out)
+    return(out)
+
+def gauss_kernel(x, x_i, rho=1.0, alpha=1.0, n_reduce=-1, point_to_flatten=1, norm = [1.0,1.0]):
+    """
+    Parameters
+    ----------
+    x : array-like
+        points required to compute kernel weight
+    x_i : array-like
+        reference points location used to compute correspondent distance of each entry points
+    rho : float
+        smoothing parameter known as "length-scale" in gaussian process
+    alpha : float
+        marginal standard deviation parameter in gaussian process; one should use 1 in kernel regression
+    point_to_flatten : float
+        the time point starting to flatten the weights; default is 1 for normalized time points
+
+    Returns
+    -------
+    np.ndarray
+        2D array with size N x M such that
+        N as the number of entry points
+        M as the number of reference points
+        matrix entries hold the value of weight of each element
+
+    See Also
+    --------
+      1. https://mc-stan.org/docs/2_24/stan-users-guide/gaussian-process-regression.html
+      2. https://en.wikipedia.org/wiki/Local_regression
+    """
+    # this section is for making an asymetric kernal
+    # sanitize the imputs 
+    norm = np.divide(np.absolute(norm),max(np.absolute(norm)),out=np.ones_like(norm), where=max(np.absolute(norm))!=0.0 )
+    norm = norm**2
+    
+    N = len(x)
+    M = len(x_i)
+    k = np.zeros((N, M), np.double)
+    alpha_sq = alpha ** 2
+    rho_sq_t2 = 2 * rho ** 2
+    
+    for n in range(N):
+        if x[n] <= point_to_flatten:
+           
+            k[n, :] = alpha_sq * np.exp(-1 * (x[n] - x_i) ** 2 / 
+                                       ( is_neg(x[n] - x_i)*rho_sq_t2*norm[0]  + (1-is_neg(x[n] - x_i))*rho_sq_t2**norm[1])) 
+                
+        else:
+            # last weights carried forward for future time points
+            k[n, :] = alpha_sq * np.exp(-1 * (point_to_flatten - x_i) ** 2 / 
+                                       ( is_neg(x[n] - x_i)*rho_sq_t2*norm[0]  + (1-is_neg(x[n] - x_i))*rho_sq_t2**norm[1])) 
+
+    if n_reduce > 0:
+       k = np.apply_along_axis(reduce_by_max, axis=1, arr=k, n=n_reduce)
+
     k = k / np.sum(k, axis=1, keepdims=True)
 
     return k


### PR DESCRIPTION
## Description
This PR is adding asymmetric kernel to KTRX. 
the argument is kernel_asym = [a,b].
a is  a multiple to the past rho and b the future rho. 
Note that a and b are normalized such that [a,b] = abs([a,b])/max(abs([a,b])). 
the default value is [1,1] so this should have no effect unless specifically used.