### PR TITLE
Update stan_estimator.py

### DIFF
--- a/orbit/estimators/stan_estimator.py
+++ b/orbit/estimators/stan_estimator.py
@@ -4,11 +4,12 @@ import logging
 import numpy as np
 from copy import copy
 import multiprocessing
+# fix issue in Python 3.9
+multiprocessing.set_start_method("fork")
 from .base_estimator import BaseEstimator
 from ..exceptions import EstimatorException
 from ..utils.stan import get_compiled_stan_model
 from ..utils.general import update_dict
-
 # todo: add stan docstrings
 
 


### PR DESCRIPTION
## Description

There was an issue in compilation of stan under Python 3.9 env.

Fixes #376 

## Type of change

Now we implement 
```
import multiprocessing
# fix issue in Python 3.9
multiprocessing.set_start_method("fork")
```

when we call `StanEstimator`

- [x] Bug fix

## How Has This Been Tested?

This happens if you run local test in python 3.9 environment; we can consider covering Python 3.9 later on. Right now, you can only test this by configuring python in local env.
