### PR TITLE
Fix logic of .isfitted()

### DIFF
--- a/orbit/models/template.py
+++ b/orbit/models/template.py
@@ -188,7 +188,12 @@ class BaseTemplate(object, metaclass=ci.DocInheritMeta(style="numpy_with_merge_d
     def is_fitted(self):
         # if either aggregate posterior and posterior_samples are non-empty, claim it as fitted model (true),
         # else false.
-        return bool(self._posterior_samples) or bool(self._aggregate_posteriors)
+        if bool(self._posterior_samples):
+            return True
+        for key in self._aggregate_posteriors.keys():
+            if bool(self._aggregate_posteriors[key]):
+                return True
+        return False
 
     def _set_dynamic_attributes(self, df):
         """Set required input based on input DataFrame, rather than at object instantiation"""

--- a/tests/orbit/models/test_ets.py
+++ b/tests/orbit/models/test_ets.py
@@ -31,7 +31,6 @@ def test_base_ets_init(model_class):
 @pytest.mark.parametrize("estimator_type", [StanEstimatorMCMC, StanEstimatorVI])
 def test_ets_full_seasonal_fit(synthetic_data, estimator_type):
     train_df, test_df, coef = synthetic_data
-
     ets = ETSFull(
         response_col='response',
         date_col='week',
@@ -42,7 +41,6 @@ def test_ets_full_seasonal_fit(synthetic_data, estimator_type):
         verbose=False,
         estimator_type=estimator_type
     )
-
     ets.fit(train_df)
 
     init_call = ets.get_init_values()
@@ -60,6 +58,8 @@ def test_ets_full_seasonal_fit(synthetic_data, estimator_type):
     assert predict_df.shape == expected_shape
     assert predict_df.columns.tolist() == expected_columns
     assert len(ets._posterior_samples) == expected_num_parameters
+
+    assert ets.is_fitted()
 
 
 @pytest.mark.parametrize("estimator_type", [StanEstimatorMCMC, StanEstimatorVI])
@@ -93,6 +93,7 @@ def test_ets_aggregated_seasonal_fit(synthetic_data, estimator_type):
     assert predict_df.shape == expected_shape
     assert predict_df.columns.tolist() == expected_columns
     assert len(ets._posterior_samples) == expected_num_parameters
+    assert ets.is_fitted()
 
 
 @pytest.mark.parametrize("estimator_type", [StanEstimatorMAP])
@@ -123,6 +124,7 @@ def test_ets_map_seasonal_fit(synthetic_data, estimator_type):
     assert predict_df.shape == expected_shape
     assert predict_df.columns.tolist() == expected_columns
     assert len(ets._posterior_samples) == expected_num_parameters
+    assert ets.is_fitted()
 
 
 @pytest.mark.parametrize("estimator_type", [StanEstimatorMCMC, StanEstimatorVI])


### PR DESCRIPTION
## Description
Propose a correct to flag fitted object by .isfitted(); either non-empty posterior_samples or non-empty of any items under aggregate posteriors would return `True`; otherwise `False`. 

Fixes #480 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix

## How Has This Been Tested?
Also added isfitted check in unitest for fitted object under ETS model.
