### PR TITLE
fix issue under python 3.9

### DIFF
--- a/orbit/estimators/stan_estimator.py
+++ b/orbit/estimators/stan_estimator.py
@@ -4,8 +4,10 @@ import logging
 import numpy as np
 from copy import copy
 import multiprocessing
-# fix issue in Python 3.9
-multiprocessing.set_start_method("fork")
+from sys import platform, version_info
+if platform == 'darwin' and version_info[0] == 3 and version_info[1] == 9:
+    # fix issue in Python 3.9
+    multiprocessing.set_start_method("fork")
 from .base_estimator import BaseEstimator
 from ..exceptions import EstimatorException
 from ..utils.stan import get_compiled_stan_model


### PR DESCRIPTION
fix #486 

`fork` is only supported for unix (including MacOS) but not windows. We only want to use this start method when it is on MacOS system and python 3.9.