### PR TITLE
raise exceptions for invalid regressors

### DIFF
--- a/orbit/template/dlt.py
+++ b/orbit/template/dlt.py
@@ -418,7 +418,6 @@ class DLTModel(ETSModel):
         if self.num_of_positive_regressors > 0:
             self.positive_regressor_matrix = df.filter(
                 items=self.positive_regressor_col, ).values
-            print("checking")
             if not np.all(np.isfinite(self.positive_regressor_matrix)):
                 raise ModelException("Invalid regressors values. They must be all not missing and finite.")
 

--- a/orbit/utils/features.py
+++ b/orbit/utils/features.py
@@ -141,4 +141,3 @@ def make_seasonal_regressors(n, periods, orders, labels, shift=0):
         fs = make_fourier_series(n=n, period=period, order=order, shift=shift)
         out[label] = fs
     return out
-

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -150,7 +150,7 @@ def synthetic_data():
     )
     df['week'] = pd.date_range(start='2016-01-04', periods=n_obs, freq='7D')
     df = df[['week', 'response'] + list('abcdef')]
-    train_df = df[df['week'] <= '2019-01-01']
-    test_df = df[df['week'] > '2019-01-01']
+    train_df = df[df['week'] <= '2019-01-01'].reset_index(drop=True)
+    test_df = df[df['week'] > '2019-01-01'].reset_index(drop=True)
 
     return train_df, test_df, coef


### PR DESCRIPTION
## Description

Include logic of detecing infinite values of regressors.  An error message will be returned specifying that regressors with invalid values are not accepted by the model.

Fixes  #560 

## Type of change

Please delete options that are not relevant.

- [x] New feature


## How Has This Been Tested?
Added cases with invalid inputs in unittests for DLT.
