### PR TITLE
replace infer_freq function with minimum timestamp difference to fix …

### DIFF
--- a/orbit/template/ktr.py
+++ b/orbit/template/ktr.py
@@ -128,7 +128,7 @@ class KTRModel(ModelTemplate):
     degree of freedom : int
         degree of freedom for error t-distribution
     date_freq : str
-        date frequency; if not supplied, pd.infer_freq will be used to imply the date frequency.
+        date frequency; if not supplied, the minimum timestamp difference in the date would be used.
     coef_prior_list : list of dicts
         each dict in the list should have keys as
         'name', prior_start_tp_idx' (inclusive), 'prior_end_tp_idx' (not inclusive),
@@ -503,7 +503,7 @@ class KTRModel(ModelTemplate):
             self._kernel_coefficients = gauss_kernel(tp, self._knots_tp_coefficients, rho=self.regression_rho)
             self._num_knots_coefficients = len(self._knots_tp_coefficients)
             if self.date_freq is None:
-                self.date_freq = pd.infer_freq(date_array)[0]
+                self.date_freq = date_array.diff().min()
             self._regression_knot_dates = get_knot_dates(date_array[0], self._regression_knots_idx, self.date_freq)
 
     def _set_knots_scale_matrix(self, df, training_meta):

--- a/orbit/template/ktrlite.py
+++ b/orbit/template/ktrlite.py
@@ -319,9 +319,7 @@ class KTRLiteModel(ModelTemplate):
         self.knots_tp_level =  (1 + self._level_knots_idx) / num_of_observations
         self.kernel_level = sandwich_kernel(tp, self.knots_tp_level)
         self.num_knots_level = len(self.knots_tp_level)
-        if self.date_freq is None:
-            self.date_freq = date_array.diff().min()
-        self._level_knot_dates = get_knot_dates(date_array[0], self._level_knots_idx, self.date_freq)
+        self._level_knot_dates = get_knot_dates(date_array, self._level_knots_idx, self.date_freq)
 
         # update rest of the seasonality related fields
         if self.num_of_regressors > 0:

--- a/orbit/template/ktrlite.py
+++ b/orbit/template/ktrlite.py
@@ -319,7 +319,9 @@ class KTRLiteModel(ModelTemplate):
         self.knots_tp_level =  (1 + self._level_knots_idx) / num_of_observations
         self.kernel_level = sandwich_kernel(tp, self.knots_tp_level)
         self.num_knots_level = len(self.knots_tp_level)
-        self._level_knot_dates = get_knot_dates(date_array, self._level_knots_idx, self.date_freq)
+        if self.date_freq is None:
+            self.date_freq = date_array.diff().min()
+        self._level_knot_dates = get_knot_dates(date_array[0], self._level_knots_idx, self.date_freq)
 
         # update rest of the seasonality related fields
         if self.num_of_regressors > 0:

--- a/orbit/template/ktrlite.py
+++ b/orbit/template/ktrlite.py
@@ -99,7 +99,7 @@ class KTRLiteModel(ModelTemplate):
     degree of freedom : int
         degree of freedom for error t-distribution
     date_freq : str
-        date frequency; if not supplied, the minimum timestamp difference in the data would be used
+        date frequency; if not supplied, the minimum timestamp difference in the date would be used
     """
     _data_input_mapper = DataInputMapper
     _model_name = 'ktrlite'

--- a/orbit/template/ktrlite.py
+++ b/orbit/template/ktrlite.py
@@ -99,7 +99,7 @@ class KTRLiteModel(ModelTemplate):
     degree of freedom : int
         degree of freedom for error t-distribution
     date_freq : str
-        date frequency; if not supplied, pd.infer_freq will be used to imply the date frequency.
+        date frequency; if not supplied, the minimum timestamp difference in the data would be used
     """
     _data_input_mapper = DataInputMapper
     _model_name = 'ktrlite'
@@ -320,7 +320,7 @@ class KTRLiteModel(ModelTemplate):
         self.kernel_level = sandwich_kernel(tp, self.knots_tp_level)
         self.num_knots_level = len(self.knots_tp_level)
         if self.date_freq is None:
-            self.date_freq = pd.infer_freq(date_array)[0]
+            self.date_freq = date_array.diff().min()
         self._level_knot_dates = get_knot_dates(date_array[0], self._level_knots_idx, self.date_freq)
 
         # update rest of the seasonality related fields

--- a/orbit/utils/knots.py
+++ b/orbit/utils/knots.py
@@ -3,14 +3,12 @@ import pandas as pd
 from ..exceptions import IllegalArgument
 
 
-def get_knot_dates(date_array, knot_idx, freq):
-    start_date = date_array[0]
+def get_knot_dates(start_date, knot_idx, freq):
 
-    if freq is None:
-        freq = date_array.diff().min()
-        knot_dates = knot_idx * freq + start_date
-    else:
+    if type(freq) is str:
         knot_dates = knot_idx * np.timedelta64(1, freq) + start_date
+    else:
+        knot_dates = knot_idx * freq + start_date
     return knot_dates
 
 

--- a/orbit/utils/knots.py
+++ b/orbit/utils/knots.py
@@ -4,11 +4,8 @@ from ..exceptions import IllegalArgument
 
 
 def get_knot_dates(start_date, knot_idx, freq):
+    knot_dates = knot_idx * freq + start_date
 
-    if type(freq) is str:
-        knot_dates = knot_idx * np.timedelta64(1, freq) + start_date
-    else:
-        knot_dates = knot_idx * freq + start_date
     return knot_dates
 
 
@@ -19,11 +16,11 @@ def get_dates_delta(start_date, end_date, freq):
     ----
     start_date : numpy datetime
     end_date : numpy datetime array
-    freq : pd.infer_freq
+    freq : pandas timedelta; min date gap
     """
     date_diff = end_date - start_date
     # can also be deemed as the "knot_idx"
-    norm_delta = np.array(date_diff / np.timedelta64(1, freq)).astype(int)
+    norm_delta = np.array(date_diff / freq).astype(int)
     return norm_delta
 
 
@@ -84,7 +81,7 @@ def get_knot_idx(
 
         if date_freq is None:
             # infer date freq if not supplied
-            date_freq = pd.infer_freq(date_array)[0]
+            date_freq = date_array.diff().min()
 
         knot_idx = get_dates_delta(
             start_date=date_array[0],

--- a/orbit/utils/knots.py
+++ b/orbit/utils/knots.py
@@ -3,8 +3,14 @@ import pandas as pd
 from ..exceptions import IllegalArgument
 
 
-def get_knot_dates(start_date, knot_idx, freq):
-    knot_dates = knot_idx * freq + start_date
+def get_knot_dates(date_array, knot_idx, freq):
+    start_date = date_array[0]
+
+    if freq is None:
+        freq = date_array.diff().min()
+        knot_dates = knot_idx * freq + start_date
+    else:
+        knot_dates = knot_idx * np.timedelta64(1, freq) + start_date
     return knot_dates
 
 

--- a/orbit/utils/knots.py
+++ b/orbit/utils/knots.py
@@ -4,7 +4,7 @@ from ..exceptions import IllegalArgument
 
 
 def get_knot_dates(start_date, knot_idx, freq):
-    knot_dates = knot_idx * np.timedelta64(1, freq) + start_date
+    knot_dates = knot_idx * freq + start_date
     return knot_dates
 
 


### PR DESCRIPTION
…incompatibility with hourly frequency time series data

## Description

Replaced pd.infer_freq with date_array.diff().min() to get the inferred frequency of a time series. This change would allow Orbit to fit hourly data.

Fixes #572 