### PR TITLE
.fit returns self

### DIFF
--- a/orbit/forecaster/full_bayes.py
+++ b/orbit/forecaster/full_bayes.py
@@ -49,6 +49,8 @@ class FullBayesianForecaster(Forecaster):
 
         self.load_extra_methods()
 
+        return self
+
     @staticmethod
     def _bootstrap(num_samples, posterior_samples, n):
         """Draw `n` number of bootstrap samples from the posterior_samples.

--- a/orbit/forecaster/map.py
+++ b/orbit/forecaster/map.py
@@ -29,6 +29,8 @@ class MAPForecaster(Forecaster):
         #  need to do it one more time to over-write the extra methods with right posterior
         self.load_extra_methods()
 
+        return self
+
     def predict(self, df, decompose=False, **kwargs):
         # raise if model is not fitted
         if not self.is_fitted():

--- a/orbit/forecaster/svi.py
+++ b/orbit/forecaster/svi.py
@@ -50,6 +50,8 @@ class SVIForecaster(Forecaster):
 
         self.load_extra_methods()
 
+        return self
+
     @staticmethod
     def _bootstrap(num_samples, posterior_samples, n):
         """Draw `n` number of bootstrap samples from the posterior_samples.


### PR DESCRIPTION
Returning self from a method simply means that the method returns a reference to the instance object on which it was called. This can sometimes be seen in use with object oriented APIs that are designed as a fluent interface that encourages method cascading.

For best practice, we will return self from .fit in orbit

fixes #555 