### PR TITLE
Update CMDSTAN_VERSION to 2.32.1 to resolve stan-dev/cmdstan#1158

### DIFF
--- a/orbit/estimators/stan_estimator.py
+++ b/orbit/estimators/stan_estimator.py
@@ -117,7 +117,6 @@ class StanEstimatorMCMC(StanEstimator):
         fitter=None,
         init_values=None,
     ):
-
         # T_STAR is used as sampling temperature which is used for WBIC calculation
         data_input.update({"T_STAR": sampling_temperature})
         if self.verbose:

--- a/orbit/template/dlt.py
+++ b/orbit/template/dlt.py
@@ -198,7 +198,6 @@ class DLTModel(ETSModel):
         forecast_horizon=1,
         **kwargs,
     ):
-
         self.damped_factor = damped_factor
         self.global_trend_option = global_trend_option
         self.period = period

--- a/orbit/template/ktr.py
+++ b/orbit/template/ktr.py
@@ -809,7 +809,6 @@ class KTRModel(ModelTemplate):
         seas_decomp = dict()
 
         if seasonality is not None and len(seasonality) > 0:
-
             date_col = training_meta[TrainingMetaKeys.DATE_COL.value]
             date_array = training_meta[TrainingMetaKeys.DATE_ARRAY.value]
             training_end = training_meta[TrainingMetaKeys.END.value]

--- a/orbit/utils/stan.py
+++ b/orbit/utils/stan.py
@@ -43,7 +43,6 @@ def compile_stan_model(stan_model_name):
     if not os.path.isfile(compiled_model) or os.path.getmtime(
         compiled_model
     ) < os.path.getmtime(source_model):
-
         logger.info(
             "First time in running stan model:{}. Expect 3 - 5 minutes for compilation.".format(
                 stan_model_name
@@ -84,7 +83,6 @@ def compile_stan_model_simplified(path):
     if not os.path.isfile(compiled_path) or os.path.getmtime(
         compiled_path
     ) < os.path.getmtime(source_path):
-
         logger.info(
             "First time in running stan model:{}. Expect 3 - 5 minutes for compilation.".format(
                 source_filename

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ from setuptools.command.build_ext import build_ext
 # dist.Distribution().fetch_build_eggs(['cython'])
 
 DESCRIPTION = "Orbit is a package for Bayesian time series modeling and inference."
-CMDSTAN_VERSION = "2.31.0"
+CMDSTAN_VERSION = "2.32.1"
 
 
 def read_long_description(filename="README.md"):


### PR DESCRIPTION
## Description

This PR fixes #822: Installation on M1 with the latest C++ compiler fails due to stan-dev/cmdstan#1158 because `orbit` uses `cmdstan==2.31.0` in `setup.py`.

This PR updates `CMDSTAN_VERSION` to `2.32.1`, which resolved the issue ([ref](https://github.com/stan-dev/cmdstan/issues/1154)).

## Type of change

Please delete options that are not relevant.

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] This change requires a documentation update
- [ ] Backend change such as github actions, travisCI etc.

## How Has This Been Tested?

