### PR TITLE
Fix cmdstanpy install issue with pip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-venv/*
+venv*
+.venv*
 env
 env3
 .idea/*

--- a/orbit/template/dlt.py
+++ b/orbit/template/dlt.py
@@ -751,10 +751,9 @@ class DLTModel(ETSModel):
                         global_trend_level + global_trend_slope * idx * self._time_delta
                     )
                 elif self.global_trend_option == GlobalTrendOption.loglinear.name:
-                    full_global_trend[
-                        :, idx
-                    ] = global_trend_level + global_trend_slope * np.log(
-                        1 + idx * self._time_delta
+                    full_global_trend[:, idx] = (
+                        global_trend_level
+                        + global_trend_slope * np.log(1 + idx * self._time_delta)
                     )
                 elif self.global_trend_option == GlobalTrendOption.logistic.name:
                     full_global_trend[:, idx] = self.global_floor + (

--- a/orbit/template/ktrlite.py
+++ b/orbit/template/ktrlite.py
@@ -190,9 +190,9 @@ class KTRLiteModel(ModelTemplate):
         init_values = None
         if len(self._seasonality) > 1 and self.num_of_regressors > 0:
             init_values = dict()
-            init_values[
-                RegressionSamplingParameters.COEFFICIENTS_KNOT.value
-            ] = np.zeros((self.num_of_regressors, self.num_knots_coefficients))
+            init_values[RegressionSamplingParameters.COEFFICIENTS_KNOT.value] = (
+                np.zeros((self.num_of_regressors, self.num_knots_coefficients))
+            )
             self._init_values = init_values
 
     def _set_default_args(self):
@@ -497,9 +497,9 @@ class KTRLiteModel(ModelTemplate):
                 seas_regression = np.sum(
                     seas_coef * seasonal_regressor_matrix.transpose(1, 0), axis=-2
                 )
-                seas_decomp[
-                    "seasonality_{}".format(self._seasonality[idx])
-                ] = seas_regression
+                seas_decomp["seasonality_{}".format(self._seasonality[idx])] = (
+                    seas_regression
+                )
                 pos += len(cols)
                 total_seas_regression += seas_regression
         if include_error:

--- a/orbit/template/lgt.py
+++ b/orbit/template/lgt.py
@@ -231,9 +231,9 @@ class LGTModel(ETSModel):
                     -1.0,
                     1.0,
                 )
-                init_values[
-                    LatentSamplingParameters.INITIAL_SEASONALITY.value
-                ] = init_sea
+                init_values[LatentSamplingParameters.INITIAL_SEASONALITY.value] = (
+                    init_sea
+                )
             if self.num_of_positive_regressors > 0:
                 x = np.clip(
                     np.random.normal(

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -2,3 +2,4 @@ pytest
 pytest-cov
 mock
 black
+wheel

--- a/setup.py
+++ b/setup.py
@@ -130,6 +130,7 @@ def prune_cmdstan(cmdstan_dir: str) -> None:
 
     rmtree(original_dir)
     temp_dir.rename(original_dir)
+    print("Pruning done")
 
 
 class BuildPyCommand(build_py):

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ def build_stan_model(target_dir):
     if os.path.isdir(cmdstan_dir):
         rmtree(cmdstan_dir)
 
+    print("complier=IS_WINDOWS=", IS_WINDOWS)
     if not cmdstanpy.install_cmdstan(
         version=CMDSTAN_VERSION,
         # if we want to do it inside the repo dir, we need to include the folder in

--- a/setup.py
+++ b/setup.py
@@ -48,15 +48,7 @@ def build_stan_model(target_dir):
 
     target_cmdstan_dir = (Path(target_dir) / f"cmdstan-{CMDSTAN_VERSION}").resolve()
     print("target_cmdstan_dir: {}".format(target_cmdstan_dir))
-
-    # For windows, install it in tmp file and then mov.
-    # BUT WHY? Why not just do it same as Mac?!a
-    if IS_WINDOWS:
-        tmp_dir = tempfile.TemporaryDirectory()
-        print("Windows detected. Use tmp_dir: {}".format(tmp_dir))
-        cmdstan_dir = (Path(tmp_dir.name) / f"cmdstan-{CMDSTAN_VERSION}").resolve()
-    else:
-        cmdstan_dir = target_cmdstan_dir
+    cmdstan_dir = target_cmdstan_dir
 
     if os.path.isdir(cmdstan_dir):
         rmtree(cmdstan_dir)
@@ -98,10 +90,6 @@ def build_stan_model(target_dir):
         print("Copying file from {} to {}".format(sm.exe_file, target_file_path))
         copy(sm.exe_file, target_file_path)
 
-    # Cleanup temp folder, copy the content into target dir first
-    copytree(cmdstan_dir, target_cmdstan_dir)
-    tmp_dir.cleanup()
-
     # TODO: some clean up needs to be done
     # 1. with the stan/ folder since it duplicates the .stan files
     # 2. the stanlib packages if it is installed with repackaged directory
@@ -110,10 +98,6 @@ def build_stan_model(target_dir):
     #         os.remove(f)
 
     if repackage_cmdstan():
-        # TODO: This step is breaking right now, as the cmdstan-2.33.1 is not in the stan_compiled folder. What's the purpose of prune?
-        # Flow:
-        # Windows: Install in temp > build various model files > **copy to target_dir > prune folder
-        # Mac: Install in target_folder > build various model files > prune folder
         prune_cmdstan(target_cmdstan_dir)
 
 

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ def build_stan_model(target_dir):
         rmtree(cmdstan_dir)
 
     print("complier=IS_WINDOWS=", IS_WINDOWS)
+    print(sys.version)
     if not cmdstanpy.install_cmdstan(
         version=CMDSTAN_VERSION,
         # if we want to do it inside the repo dir, we need to include the folder in

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ def build_stan_model(target_dir):
         version=CMDSTAN_VERSION,
         # if we want to do it inside the repo dir, we need to include the folder in
         # MANIFEST.in
-        dir=cmdstan_dir.parent,
+        # dir=cmdstan_dir.parent,
         overwrite=True,
         verbose=True,
         cores=cpu_count(),

--- a/setup.py
+++ b/setup.py
@@ -46,15 +46,13 @@ def build_stan_model(target_dir):
     import cmdstanpy
     from multiprocessing import cpu_count
 
-    target_cmdstan_dir = (Path(target_dir) / f"cmdstan-{CMDSTAN_VERSION}").resolve()
-    print("target_cmdstan_dir: {}".format(target_cmdstan_dir))
-    cmdstan_dir = target_cmdstan_dir
+    # target_cmdstan_dir = (Path(target_dir) / f"cmdstan-{CMDSTAN_VERSION}").resolve()
+    # print("target_cmdstan_dir: {}".format(target_cmdstan_dir))
+    # cmdstan_dir = target_cmdstan_dir
 
-    if os.path.isdir(cmdstan_dir):
-        rmtree(cmdstan_dir)
+    # if os.path.isdir(cmdstan_dir):
+    #     rmtree(cmdstan_dir)
 
-    print("complier=IS_WINDOWS=", IS_WINDOWS)
-    print(sys.version)
     if not cmdstanpy.install_cmdstan(
         version=CMDSTAN_VERSION,
         # if we want to do it inside the repo dir, we need to include the folder in
@@ -69,6 +67,10 @@ def build_stan_model(target_dir):
         raise RuntimeError("CmdStan failed to install in repackaged directory")
     else:
         print("Installed cmdstanpy package.")
+
+    from cmdstanpy import cmdstan_path, set_cmdstan_path
+
+    cmdstan_dir = cmstan_path()
 
     print("cmdstan_dir: {}".format(cmdstan_dir))
     for model in MODELS:
@@ -100,7 +102,7 @@ def build_stan_model(target_dir):
     #         os.remove(f)
 
     if repackage_cmdstan():
-        prune_cmdstan(target_cmdstan_dir)
+        prune_cmdstan(cmdstan_dir)
 
 
 def repackage_cmdstan():


### PR DESCRIPTION
## Description

In Windows using the windows store's python distributions and venv, installation of the package would break during installation of cmdStan and creation of the complied stan binaries. This is caused by usage of temp folder, having to move things around from temp to package directory, as well as missing complier in Windows.

Fix: Simplified setup.py workflow by aligning installing workflow with non-window machines. Adds `complier=True` flag to `cmdstanpy.install_cmdstan`. Tested on python 3.9-3.11 venvs.

Fixes #808 

## Type of change
- [ x] Bug fix

## How Has This Been Tested?

- Created venv using targed python version
- install requirements, requirements-test, and install local package (`pip install -e .`)
- Install package and run demo code specified in readme.md, confirmed working
- Ran unit tests according to contribution guideline, confirmed all passed
- Tested in windows, WSL.