### PR TITLE
Cmdstanpy version, and force compile logic

### DIFF
--- a/orbit/utils/stan.py
+++ b/orbit/utils/stan.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 import json
 import os
 import platform
@@ -28,6 +29,12 @@ if IS_WINDOWS:
     for path_string in paths:
         # or use sys.path.append, potentially works across platforms
         os.environ["Path"] += ";" + os.path.normpath(os.path.expanduser(path_string))
+
+
+def get_file_time(path: str):
+    return datetime.fromtimestamp(os.path.getmtime(path)).replace(
+        second=0, microsecond=0
+    )
 
 
 def get_compiled_stan_model(
@@ -71,13 +78,14 @@ def get_compiled_stan_model(
         )
         # Check if exe is older than .stan file.
         # This behavior is default on CmdStanModel if we don't have to specify the exe_file.
-        # if not os.path.isfile(exe_file) or (
-        #     os.path.getmtime(exe_file) <= os.path.getmtime(stan_file)
-        # ):
+        if not os.path.isfile(exe_file) or (
+            get_file_time(exe_file) <= get_file_time(stan_file)
+        ):
+            force_compile = True
 
         if not os.path.isfile(exe_file) or force_compile:
             logger.info(f"Compiling stan model:{stan_file}. ETA 3 - 5 mins.")
-            sm = CmdStanModel(stan_file=stan_file)
+            sm = CmdStanModel(stan_file=stan_file, force_compile=force_compile)
         else:
             sm = CmdStanModel(stan_file=stan_file, exe_file=exe_file)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ readme = "README.md"
 requires-python = ">=3.7"
 dependencies = [
   "arviz",
-  "cmdstanpy>=1.0.4",
+  "cmdstanpy>=1.2.1",
   "importlib_resources",
   "matplotlib>=3.3.2",
   "numpy>=1.18",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 arviz
-cmdstanpy>=1.0.4
+cmdstanpy>=1.2.1
 importlib_resources
 ipywidgets
 matplotlib>=3.3.2


### PR DESCRIPTION
## Description

Reinstate force compile logic if executable time is <= stan file time, to brute force remove bundled executable (for conda)

Bump cmdstanpy version to 1.2.1

Fixes #864 

## Type of change

Please delete options that are not relevant.

- [ x ] Bug fix
